### PR TITLE
Update docker-compose.yml to remove extrahosts for ckan

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -87,8 +87,7 @@ services:
     restart: unless-stopped
     healthcheck:
       test: ["CMD", "wget", "-qO", "/dev/null", "http://localhost:5000"]
-    extra_hosts:
-      - "${ID_HOSTNAME}:host-gateway"
+    
 
   postgres:
     build:


### PR DESCRIPTION
the extrahosts line in ckan service makes it that when ckan try to reach keycloak via dns it is redirected to the localmachine instead of the public endpoint